### PR TITLE
No longer crashes with Invariant Violation: Tried to get frame for out of range index NaN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "expo-image-picker-multiple",
+  "version": "1.1.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "expo-screen-orientation": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/expo-screen-orientation/-/expo-screen-orientation-1.0.0.tgz",
+      "integrity": "sha512-McYHWSA3KVgh3IeztKg0oxkHtSRzDfqGRSHg6GgIici5C93LOF4tGzO38tLNVGXIjbu8EdvBRB7pslKS73AXGg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
   },
   "homepage": "https://github.com/MonstroDev/expo-image-picker-multiple#readme",
   "dependencies": {
+    "expo-media-library": "^8.0.0",
     "expo-permissions": "^8.0.0",
-    "expo-media-library": "^8.0.0"
+    "expo-screen-orientation": "^1.0.0"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -6,7 +6,7 @@ import {
   Dimensions,
   ActivityIndicator,
 } from 'react-native'
-import { ScreenOrientation } from 'expo';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import * as MediaLibrary from 'expo-media-library'
 import * as Permissions from 'expo-permissions'
 import ImageTile from './ImageTile'
@@ -29,7 +29,7 @@ export default class ImageBrowser extends React.Component {
     await this.getPermissionsAsync();
     ScreenOrientation.addOrientationChangeListener(this.onOrientationChange);
     const orientation = await ScreenOrientation.getOrientationAsync();
-    const numColumns = this.getNumColumns(orientation.orientation);
+    const numColumns = this.getNumColumns(orientation);
     this.setState({numColumns});
     this.getPhotos();
   }
@@ -50,7 +50,7 @@ export default class ImageBrowser extends React.Component {
     this.setState({numColumns});
   }
 
-  getNumColumns = orientation => orientation.indexOf('PORTRAIT') !== -1 ? 4 : 7;
+  getNumColumns = orientation => orientation !== ScreenOrientation.Orientation.PORTRAIT_UP ? 4 : 7;
 
   selectImage = (index) => {
     let newSelected = Array.from(this.state.selected);


### PR DESCRIPTION
In the most recent expo sdk 37 the method getorientationasync() returns an integer instead of an orientation object, modified code to work with the new return type

Also updated the expo ScreenOrientation import statement