### PR TITLE
FIX: `callback` was never called

### DIFF
--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -67,7 +67,7 @@ export default class ImageBrowser extends React.Component {
     if (newSelected.length > this.props.max) return;
     if (!newSelected) newSelected = []; 
     this.setState({selected: newSelected}, () =>{
-      this.props.onChange(newSelected.length, () => this.prepareCallback());
+      this.props.onChange(newSelected.length, this.prepareCallback());
     });
   }
 


### PR DESCRIPTION
FIX: `onChange` handler always got undefined as second param; `callback` handler was never invoked

I have also created an [example repo](https://github.com/gregfenton/expo-image-picker-multiple-example) that uses Expo SDK 39.0.0.  Feel free to use as you care to.