### PR TITLE
Fix getAssetInfoAsync 

### DIFF
--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -106,7 +106,7 @@ export default class ImageBrowser extends React.Component {
   prepareCallback() {
     const { selected, photos } = this.state;
     const selectedPhotos = selected.map(i => photos[i]);
-    const assetsInfo = Promise.all(selectedPhotos.map(i => MediaLibrary.getAssetInfoAsync(i)));
+    const assetsInfo = Promise.all(selectedPhotos);
     this.props.callback(assetsInfo);
   }
 


### PR DESCRIPTION
I got error message [ Native method ExponentMediaLibrary.getAssetInfoAsync expects 1 argument but received 2 ]
Thus, I delete the getAssetInfoAsync, and It work on both android and iOS. 
Expo SDK 37