### PR TITLE
Proper permission for deprecated CAMERA_ROLL.

### DIFF
--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -43,7 +43,7 @@ export default class ImageBrowser extends React.Component {
 
   getPermissionsAsync = async () => {
     const {status: camera} = await Permissions.askAsync(Permissions.CAMERA);
-    const {status: cameraRoll} = await Permissions.askAsync(Permissions.CAMERA_ROLL);
+    const {status: cameraRoll} = await Permissions.askAsync(Permissions.MEDIA_LIBRARY);
     this.setState({
       hasCameraPermission: camera === 'granted',
       hasCameraRollPermission: cameraRoll === 'granted'


### PR DESCRIPTION
Permission.CAMERA_ROLL has been replaced by Permission.MEDIA_LIBRARY in EXPO SDK40.