### PR TITLE
Remove listener on dismount to prevent memory leak

### DIFF
--- a/src/ImageBrowser.js
+++ b/src/ImageBrowser.js
@@ -42,6 +42,10 @@ export default class ImageBrowser extends React.Component {
     this.getPhotos();
   }
 
+  componentWillUnmount() {
+    ScreenOrientation.removeOrientationChangeListeners()
+  }
+
   getPermissionsAsync = async () => {
     const {status: camera} = await Permissions.askAsync(Permissions.CAMERA);
     const {status: cameraRoll} = await Permissions.askAsync(Permissions.MEDIA_LIBRARY);


### PR DESCRIPTION
Was getting a warning in expo upon closing the image-browser that I had a memory leak. Noticed ImageBrowser did not contain a componentWillUnmount lifecycle method to clear the orientation listener, so added it in.