### PR TITLE
expo-screen-rotation upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/MonstroDev/expo-image-picker-multiple#readme",
   "dependencies": {
-    "expo-screen-orientation": "^3.0.0"
+    "expo-screen-orientation": "^4.0.0"
   },
   "peerDependencies": {
     "react-native": "*"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/MonstroDev/expo-image-picker-multiple#readme",
   "dependencies": {
-    "expo-screen-orientation": "^4.0.0"
+    "expo-screen-orientation": "^4.3.0"
   },
   "peerDependencies": {
     "react-native": "*"


### PR DESCRIPTION
expo-screen-rotation (< v.4.0.0) is using deprecated @unimodules/core, it's causing some problems with dependencies.